### PR TITLE
LP_Reporter: Add suffix for metrics path.

### DIFF
--- a/pyformance/reporters/influx.py
+++ b/pyformance/reporters/influx.py
@@ -170,6 +170,7 @@ class InfluxReporter(Reporter):
         for file in files:
             with open(file, "r") as metrics_file:
                 url = self._get_url()
+                LOG.debug(f"Reporting file {metrics_file.name} with data: {metrics_file.read()}")
                 if self._try_send(url, metrics_file.read()):
                     self.reported_files.append(file)
 

--- a/pyformance/reporters/line_protocol_reporter.py
+++ b/pyformance/reporters/line_protocol_reporter.py
@@ -26,8 +26,9 @@ class LineProtocolReporter(Reporter):
             self,
             registry: MetricsRegistry = None,
             reporting_interval: int = 30,
-            path: str = "/tmp/metrics",
             prefix: str = "",
+            path: str | None = None,
+            path_suffix: str | None = None,
             clock: time = None,
             global_tags: dict = None,
             reporting_precision = ReportingPrecision.SECONDS,
@@ -38,7 +39,7 @@ class LineProtocolReporter(Reporter):
         coarse precision may result in significant improvements in compression and vice versa.
         """
         super(LineProtocolReporter, self).__init__(registry, reporting_interval, clock)
-        self.path = path
+        self.path = self._set_path(path, path_suffix)
         self.prefix = prefix
 
         if not os.path.exists(self.path):
@@ -130,6 +131,16 @@ class LineProtocolReporter(Reporter):
             )
 
         return ""
+
+    @staticmethod
+    def _set_path(path: str | None, path_suffix: str | None) -> str:
+        if not path:
+            path = f"/tmp/metrics"
+        if path_suffix:
+            path += f"/{path_suffix}"
+
+        os.environ["METRICS_REPORTER_FOLDER_PATH"] = path
+        return path
 
 def _format_field_value(value) -> str:
     if isinstance(value, MarkInt):


### PR DESCRIPTION
In addition set `METRICS_REPORTER_FOLDER_PATH` for future use.