### PR TITLE
fix: Remove deprecated pkg_resources usage to support setuptools>=81

### DIFF
--- a/pyformance/__init__.py
+++ b/pyformance/__init__.py
@@ -1,4 +1,12 @@
-__import__("pkg_resources").declare_namespace(__name__)
+# Maintain backwards compatibility while avoiding deprecation warnings
+import sys
+if sys.version_info < (3, 3):
+    # Only use pkg_resources for Python < 3.3 which doesn't support PEP 420
+    try:
+        __import__("pkg_resources").declare_namespace(__name__)
+    except ImportError:
+        pass
+# For Python 3.3+, namespace packages work automatically (PEP 420)
 
 from .registry import MetricsRegistry, global_registry, set_global_registry
 from .registry import timer, counter, meter, histogram, gauge, event


### PR DESCRIPTION
The pkg_resources.declare_namespace() call is deprecated and will be removed from setuptools as early as 2025-11-30. This was causing UserWarning messages in environments with newer setuptools versions.

Modern Python (3.3+) handles namespace packages automatically via PEP 420, making the declare_namespace() call unnecessary. Added backwards compatibility check for Python 2.7 and older Python 3 versions that might still need it.

This change:
- Eliminates deprecation warnings in modern environments
- Maintains compatibility with older Python versions
- Prepares the codebase for setuptools>=81